### PR TITLE
fix(toast): loading图标不居中

### DIFF
--- a/components/Indicator/index.js
+++ b/components/Indicator/index.js
@@ -24,7 +24,7 @@ const Indicator = (props) => {
     return (
         <div className={cls} {...restProps}>
             <Image name={spinnerImg} className={imgCls} />
-            <span className={textCls} style={textStyle}>{text}</span>
+            { text ? <span className={textCls} style={textStyle}>{text}</span> : null }
         </div>
     );
 };


### PR DESCRIPTION
修复Indicator导致的toast.loading不居中